### PR TITLE
Change the demographic variables pulled from PSID

### DIFF
--- a/ogusa_calibrate/data/PSID/psid_download.R
+++ b/ogusa_calibrate/data/PSID/psid_download.R
@@ -28,8 +28,7 @@ family_var_names <- list(# Family variables
                         spouse_age="ER47319",
                         head_gender="ER47318",
                         head_num_children="V10977",
-                        num_children="ER37724",
-                        num_children_away_from_home="V561",
+                        num_family="ER66016",
                         num_children_under18="ER47320",
                         # race
                         head_race="ER64810",


### PR DESCRIPTION
Fixes #20, removes `num_children` and `num_children_away_from_home`, available for only 1 and 2 years of data respectively. Adds `num_family` with the total number of family members with data for nearly every year.